### PR TITLE
adjusted vcenter advanced tab

### DIFF
--- a/src/sunstone/public/app/tabs/templates-tab/form-panels/instantiate.js
+++ b/src/sunstone/public/app/tabs/templates-tab/form-panels/instantiate.js
@@ -522,10 +522,12 @@ define(function(require) {
           VMGroupSection.insert(template_json,
             $(".vmgroupContext"+ template_json.VMTEMPLATE.ID, context));
 
+          if (Config.isFeatureEnabled("vcenter_vm_folder")){
           vcenterVMFolderContext = $(".vcenterVMFolderContext"  + template_json.VMTEMPLATE.ID, context);
           VcenterVMFolder.setup(vcenterVMFolderContext);
           VcenterVMFolder.fill(vcenterVMFolderContext, template_json.VMTEMPLATE);
-
+          }
+          
           var inputs_div = $(".template_user_inputs" + template_json.VMTEMPLATE.ID, context);
 
           UserInputs.vmTemplateInsert(

--- a/src/sunstone/public/app/tabs/templates-tab/form-panels/instantiate/templateRow.hbs
+++ b/src/sunstone/public/app/tabs/templates-tab/form-panels/instantiate/templateRow.hbs
@@ -144,6 +144,7 @@
   </div>
   {{/isFeatureEnabled}}
   {{/advancedImportationSection}}
+  {{#isFeatureEnabled "vcenter_vm_folder"}}
   {{#advancedImportationSection "<i class=\"fas fa-folder\"></i>" (tr "vCenter Deployment") }}
   <div class="row">
     <div class="medium-6 small-12 columns vcenterVMFolderContext{{element.ID}}">
@@ -152,5 +153,6 @@
     </div>
   </div>
   {{/advancedImportationSection}}
+  {{/isFeatureEnabled }}
 </div>
 <br>


### PR DESCRIPTION
Vcenter advanced tab is not removed in favour of stability instead can be enabled or disabled from sunstone config(/etc/one/sunstone-views/ variable is  "vcenter_vm_folder")